### PR TITLE
Fix pthread_yield() not supported by OS X

### DIFF
--- a/emu/src/process.h
+++ b/emu/src/process.h
@@ -1,6 +1,11 @@
 #ifndef EMULATOR_PROCESS_H
 
 #include <pthread.h>
+// OS X does not support pthread_yield(), only pthread_yield_np()
+#if defined(__APPLE__) || defined(__MACH__)
+#define pthread_yield() pthread_yield_np()
+#endif
+
 #include <stdarg.h>
 
 #define MAX_ARGS 8


### PR DESCRIPTION
This is a proposal to fix the transputer emulator on OS X which fails to build because `phread_yield()` is not supported by OS X.

Running `make all` by OS X results in this build error:

```
...
Undefined symbols for architecture x86_64:
  "_pthread_yield", referenced from:
      _ProcReschedule in emulation.a(process.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [tsp.par.intern] Error 1
make[1]: *** [tsp.par] Error 2
make: *** [all] Error 2
```

See here for further discussion on the issue:
https://github.com/01org/ocr/issues/28

And here for the diff between pthread_yield() and pthread_yield_np():
http://www.linuxquestions.org/questions/programming-9/pthread_yield-vs-pthread_yield_np-469283/